### PR TITLE
Minor fixup & improvement

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/misc/Misc.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/misc/Misc.java
@@ -61,7 +61,7 @@ public class Misc {
 
     private static final String DOZE = "dumpsys deviceidle";
 
-    private static final String HAPTICS = "/sys/devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,haptics@c000/leds/vibrator";
+    private static final String HAPTICS = "/sys/class/leds/vibrator";
     private static final String HAPTICS_OVERRIDE = HAPTICS + "/vmax_override";
     private static final String HAPTICS_USER = HAPTICS + "/vmax_mv_user";
     private static final String HAPTICS_NOTIFICATION = HAPTICS + "/vmax_mv_strong";

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/wake/Dt2w.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/wake/Dt2w.java
@@ -57,6 +57,7 @@ public class Dt2w {
     private static final String DT2W_FT5X06 = "/sys/bus/i2c/drivers/ft5x06_i2c/5-0038/d2w_switch";
     private static final String LENOVO_DT2W = "/sys/lenovo_tp_gestures/tpd_suspend_status";
     private static final String DT2W_SMDK4412 = "/sys/devices/virtual/misc/touchwake/knockon";
+    private static final String ENABLE_DT2W = "/proc/touchpanel/enable_dt2w";
 
     private final HashMap<String, List<Integer>> mFiles = new HashMap<>();
     private final List<Integer> mLgeTouchCoreMenu = new ArrayList<>();
@@ -85,6 +86,7 @@ public class Dt2w {
         mFiles.put(DT2W_FT5X06, mGenericMenu);
         mFiles.put(LENOVO_DT2W, mGenericMenu);
         mFiles.put(DT2W_SMDK4412, mGenericMenu);
+        mFiles.put(ENABLE_DT2W, mGenericMenu);
     }
 
     private String FILE;


### PR DESCRIPTION
6b11491d86adc46f76c3c4453f3c8e12fbf148b4: Technically this D2TW path used by the Xiaomi devices such as Mi A1 and Redmi Note 4X.
a1c440e7ed79fcf70bada86184c432b8f9d08cc8: Vibration control is based on flar commit which directs the module to `/sys/class/leds/vibrator`, rather than using linked path (not all devices are the same) it is better to use the original path.

I attach the application below if anyone wants to test it
Android Studio version: 3.5.0-beta05
Gradle version: 5.4.1
[Download here](https://drive.google.com/open?id=1sMp9NEH9TbM-2vvdC0vfvlxvzxN3F_fA)