### PR TITLE
Cpu input boost info correction

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,7 +202,7 @@
 
     <!-- CPU Input Boost -->
     <string name="cpu_input_boost">CPU Input Boost</string>
-    <string name="cpu_input_boost_summary">Enable CPU Input Boost, an event-based CPU boosting driver by Sultanxda.</string>
+    <string name="cpu_input_boost_summary">Enable CPU Input Boost, CPU boosting driver by Sultanxda.</string>
     <string name="cpuiboost_duration">Input Boost Duration</string>
     <string name="cpuiboost_duration_summary">Set CPU Input Boost duration</string>
     <string name="wake_boost_duration">Wake Boost Duration</string>


### PR DESCRIPTION
sultan's CPU input boost is not a event based on legacy devices.. So just declare it as cpu boosting by sultan xda.